### PR TITLE
ハンバーガーメニューの閉じるボタンのスタイル変更

### DIFF
--- a/apps/frontend/src/components/Elements/Header/HamburgerMenu.tsx
+++ b/apps/frontend/src/components/Elements/Header/HamburgerMenu.tsx
@@ -50,7 +50,7 @@ export const HamburgerMenu = ({ onClose }: HamburgerMenuProps): JSX.Element => {
           icon={faXmark}
           onClick={onClose}
           color='secondary'
-          className='w-6'
+          className='w-8'
         />
       </div>
 


### PR DESCRIPTION
## Issue

- close #325 

## 概要
ハンバーガーメニューの閉じるボタンのサイズを変更しました。

## スクリーンショット

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img width="362" alt="Notification_Center" src="https://user-images.githubusercontent.com/70331644/236417661-fdc6ed87-3680-40e2-8359-0ab94241c16b.png"> | <img width="363" alt="FC-PUENTET_公式サイト" src="https://user-images.githubusercontent.com/70331644/236417571-c730214e-ccd0-48ec-a75e-2780b5eb2ab1.png"> |
