### PR TITLE
:+1: Newsをテーブル構成に合わせて変更

### DIFF
--- a/apps/frontend/src/features/news/components/NewsCard.tsx
+++ b/apps/frontend/src/features/news/components/NewsCard.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { News } from '../types';
 import { formatDate } from '@/utils';
+import Image from 'next/image';
 
 interface NewsCardProps {
   news: News;
@@ -9,15 +10,26 @@ interface NewsCardProps {
 export const NewsCard: React.FC<NewsCardProps> = ({ news }) => {
   return (
     <Link
-      href={`/news/${news.id}`}
+      href={`/news/${news.slug}`}
       className='relative block h-[400px] w-[300px] cursor-pointer shadow-xl'
     >
-      {/* TODO: DBにサムネイルカラムが追加後に対応 */}
-      <img
-        src='/gray-scale.svg'
-        alt={news.title}
-        className='h-[400px] w-[300px] object-cover'
-      />
+      {news.coverImage ? (
+        <Image
+          src={news.coverImage.src}
+          alt={news.coverImage.fileName}
+          width={news.coverImage.width}
+          height={news.coverImage.height}
+          className='h-[400px] w-[300px] object-cover'
+        />
+      ) : (
+        <Image
+          src='/gray-scale.svg'
+          alt='empty'
+          width={300}
+          height={400}
+          className='h-[400px] w-[300px] object-cover'
+        />
+      )}
       <div className='absolute bottom-0 flex h-[100px] w-full flex-col justify-between bg-black/50 p-2 text-white backdrop-blur-lg'>
         <p className='line-clamp-2'>{news.title}</p>
         <p className='text-right'>{formatDate(news.updatedAtString)}</p>

--- a/apps/frontend/src/features/news/components/NewsCard.tsx
+++ b/apps/frontend/src/features/news/components/NewsCard.tsx
@@ -1,7 +1,7 @@
+import Image from 'next/image';
 import Link from 'next/link';
 import { News } from '../types';
 import { formatDate } from '@/utils';
-import Image from 'next/image';
 
 interface NewsCardProps {
   news: News;

--- a/apps/frontend/src/features/news/components/NewsContent.tsx
+++ b/apps/frontend/src/features/news/components/NewsContent.tsx
@@ -1,10 +1,10 @@
 import { marked } from 'marked';
 import React from 'react';
-import { News } from '@/features/news';
+import { NewsDetail } from '@/features/news';
 import { formatDateTime } from '@/utils';
 
 type Props = React.HTMLAttributes<HTMLDivElement> & {
-  news: News;
+  news: NewsDetail;
 };
 
 export const NewsContent: React.FC<Props> = ({

--- a/apps/frontend/src/features/news/components/NewsListContent.tsx
+++ b/apps/frontend/src/features/news/components/NewsListContent.tsx
@@ -11,7 +11,7 @@ export const NewsListContent: React.FC<NewsListContentProps> = ({ news }: NewsLi
   return (
     <li className='my-6 block cursor-pointer select-none rounded-lg border border-gray-200 bg-white p-6 shadow-md hover:bg-gray-100'>
       <Link
-        href={`/news/${news.id}`}
+        href={`/news/${news.slug}`}
         className='flex flex-col justify-between md:flex-row md:items-center'
       >
         <h5 className='mb-2 text-xl font-bold tracking-tight text-gray-900 lg:text-2xl'>

--- a/apps/frontend/src/features/news/types/news.ts
+++ b/apps/frontend/src/features/news/types/news.ts
@@ -4,4 +4,20 @@ export interface News {
   updatedAtString: string;
   title: string;
   content: string;
+  slug: string;
+  coverImage: {
+    src: string;
+    fileName: string;
+    height: number;
+    width: number;
+  } | null;
+}
+
+export interface NewsDetail {
+  id: string;
+  createdAtString: string;
+  updatedAtString: string;
+  title: string;
+  content: string;
+  slug: string;
 }

--- a/apps/frontend/src/pages/index.tsx
+++ b/apps/frontend/src/pages/index.tsx
@@ -56,7 +56,9 @@ export const getStaticProps: GetStaticProps<TopScreenProps> = async () => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const { data: newsData } = await supabase
     .from('news')
-    .select('id, created_at, updated_at, title, content')
+    .select(
+      'id, created_at, updated_at, title, content, assets:cover_image_asset_id(src, file_name, height, width), slug',
+    )
     .is('deleted_at', null)
     .order('created_at', { ascending: false })
     .limit(TOP_NEWS_MAX_COUNT);
@@ -70,6 +72,13 @@ export const getStaticProps: GetStaticProps<TopScreenProps> = async () => {
         updatedAtString: `${entity.updated_at}`,
         title: `${entity.title}`,
         content: `${entity.content}`,
+        slug: `${entity.slug}`,
+        coverImage: entity.assets && {
+          src: `${entity.assets.src}`,
+          fileName: `${entity.assets.file_name}`,
+          height: entity.assets.height,
+          width: entity.assets.width,
+        },
       };
     }) ?? [];
   /* eslint-enable */

--- a/apps/frontend/src/pages/news/[id].tsx
+++ b/apps/frontend/src/pages/news/[id].tsx
@@ -4,11 +4,11 @@ import { useRouter } from 'next/router';
 import React from 'react';
 import { TitleHeader } from '@/components/Elements';
 import { ContentLayout, MainLayout } from '@/components/Layout';
-import { NewsContent, News } from '@/features/news';
+import { NewsContent, NewsDetail } from '@/features/news';
 import { supabase } from '@/utils';
 
 interface NewsContentScreenProps {
-  news: News;
+  news: NewsDetail;
 }
 
 const NewsContentScreen: NextPage<NewsContentScreenProps> = ({ news }) => {
@@ -21,7 +21,7 @@ const NewsContentScreen: NextPage<NewsContentScreenProps> = ({ news }) => {
       exit={{ opacity: 0 }}
     >
       <MainLayout
-        path={`/news/${news.id}`}
+        path={`/news/${news.slug}`}
         title={news.title}
       >
         <ContentLayout className='pt-32 pb-8'>
@@ -71,7 +71,7 @@ export const getStaticProps: GetStaticProps<NewsContentScreenProps> = async (con
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const { data: entity, error } = await supabase
     .from('news')
-    .select('id, created_at, updated_at, title, content')
+    .select('id, created_at, updated_at, title, content, slug')
     .is('deleted_at', null)
     .eq('id', context.params?.id)
     .single();
@@ -89,6 +89,7 @@ export const getStaticProps: GetStaticProps<NewsContentScreenProps> = async (con
     updatedAtString: `${entity.updated_at}`,
     title: `${entity.title}`,
     content: `${entity.content}`,
+    slug: `${entity.slug}`,
   };
   /* eslint-enable */
 

--- a/apps/frontend/src/pages/news/index.tsx
+++ b/apps/frontend/src/pages/news/index.tsx
@@ -47,7 +47,9 @@ export const getStaticProps: GetStaticProps<NewsListScreenProps> = async () => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const { data } = await supabase
     .from('news')
-    .select('id, created_at, updated_at, title, content')
+    .select(
+      'id, created_at, updated_at, title, content, assets:cover_image_asset_id(src, file_name, height, width), slug',
+    )
     .is('deleted_at', null)
     .order('created_at', { ascending: false });
 
@@ -60,6 +62,13 @@ export const getStaticProps: GetStaticProps<NewsListScreenProps> = async () => {
         updatedAtString: `${entity.updated_at}`,
         title: `${entity.title}`,
         content: `${entity.content}`,
+        slug: `${entity.slug}`,
+        coverImage: entity.assets && {
+          src: `${entity.assets.src}`,
+          fileName: `${entity.assets.file_name}`,
+          height: entity.assets.height,
+          width: entity.assets.width,
+        },
       };
     }) ?? [];
   /* eslint-enable */


### PR DESCRIPTION
## Issue

- close #337 🦕
- close #338 🦕

## 概要
Newsをテーブル構成に合わせて以下の変更を行いました。
- カバーイメージの設定
- ページ遷移をidからslugへ変更

## レビュー観点
- 問題なく動作するか

## レビューレベル

- [ ] Lv0: まったく見ないで Approve する
- [ ] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [x] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [ ] 今日〜明日中で見てもらいたい 🚶
- [x] 数日以内で見てもらいたい 🐢

## 参考リンク

<!-- 参考文献などがあればここに記入してください。 -->

-

## スクリーンショット

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |
